### PR TITLE
Allow configuring Ollama base URL via settings or env

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ pip install -r requirements.txt
 # Variables de entorno (ejemplo)
 export DATABASE_URL=postgresql://usuario:password@localhost:5432/gestorrequisitos
 export SECRET_KEY=clave_secreta
+# URL base de Ollama (opcional, por defecto http://localhost:11434)
 export OLLAMA_URL=http://localhost:11434
 
 # Crear tablas
@@ -118,6 +119,10 @@ Los prompts están en **static/prompts/*.txt** y se formatean con **prompt_loade
 
 ## Modelos soportados:
 Por defecto llama3:8b pero configurable vía OLLAMA_MODEL.
+
+La URL base del servicio Ollama se configura mediante `OLLAMA_URL` o el
+atributo `ollama_url` en `Settings`; si no se especifica, se usará
+`http://localhost:11434`.
 
 ## Modo stall:
 Los mensajes se envían sin prompt fijo; el backend compone contexto con la conversación previa y requisitos actuales.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -4,6 +4,7 @@ from typing import List
 class Settings(BaseSettings):
     database_url: str
     backend_cors_origins: str = "http://localhost:5173"
+    ollama_url: str = "http://localhost:11434"
 
     class Config:
         env_file = ".env"

--- a/app/utils/ollama_client.py
+++ b/app/utils/ollama_client.py
@@ -1,15 +1,24 @@
-import requests
+import os
+from typing import Optional
 
-def call_ollama(prompt: str, model: str = "llama3:8b") -> str:
-    """
-    Llama al endpoint de generación de Ollama con el prompt indicado.
-    """
+import requests
+from app.core.config import Settings
+
+
+def call_ollama(prompt: str, model: str = "llama3:8b", settings: Optional[Settings] = None) -> str:
+    """Llama al endpoint de generación de Ollama con el prompt indicado."""
+    base_url = os.environ.get("OLLAMA_URL")
+    if not base_url:
+        if settings is None:
+            settings = Settings()
+        base_url = getattr(settings, "ollama_url", "http://localhost:11434")
+
     response = requests.post(
-        "http://localhost:11434/api/generate",
+        base_url.rstrip("/") + "/api/generate",
         json={
             "model": model,
             "prompt": prompt,
-            "stream": False
+            "stream": False,
         },
         timeout=60,
     )


### PR DESCRIPTION
## Summary
- Read `OLLAMA_URL` from environment or Settings instead of using a hardcoded localhost URL
- Expose `ollama_url` in Settings with default and document configuration in README

## Testing
- `python -m py_compile app/utils/ollama_client.py app/core/config.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689857b80b5c8332a09d8bccab0d00bf