### PR TITLE
Use stored preferences in user profile endpoint

### DIFF
--- a/app/api/endpoints/auth.py
+++ b/app/api/endpoints/auth.py
@@ -77,5 +77,7 @@ def me(current_user: User = Depends(get_current_user)):
         created_date=current_user.created_date,
         updated_date=current_user.updated_date,
         active=current_user.active,
-        preferences=None
+        preferences=UserPreferences(**current_user.preferences)
+        if current_user.preferences
+        else UserPreferences()
     )


### PR DESCRIPTION
## Summary
- Return current user's stored preferences in `/auth/me` response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689869accc5c833293680103898288d3