### PR TITLE
Wrap requests error handling in Ollama client

### DIFF
--- a/app/utils/ollama_client.py
+++ b/app/utils/ollama_client.py
@@ -1,8 +1,12 @@
+import logging
 import os
 from typing import Optional
 
 import requests
 from app.core.config import Settings
+
+
+logger = logging.getLogger(__name__)
 
 
 def call_ollama(prompt: str, model: str = "llama3:8b", settings: Optional[Settings] = None) -> str:
@@ -13,15 +17,26 @@ def call_ollama(prompt: str, model: str = "llama3:8b", settings: Optional[Settin
             settings = Settings()
         base_url = getattr(settings, "ollama_url", "http://localhost:11434")
 
-    response = requests.post(
-        base_url.rstrip("/") + "/api/generate",
-        json={
-            "model": model,
-            "prompt": prompt,
-            "stream": False,
-        },
-        timeout=60,
-    )
-    response.raise_for_status()
+    try:
+        response = requests.post(
+            base_url.rstrip("/") + "/api/generate",
+            json={
+                "model": model,
+                "prompt": prompt,
+                "stream": False,
+            },
+            timeout=60,
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        content = getattr(exc.response, "text", "")
+        if content:
+            logger.error("Ollama request failed: %s", content)
+        else:
+            logger.error("Ollama request failed: %s", exc)
+        raise RuntimeError(
+            f"Error calling Ollama at {base_url}: {content or exc}"
+        ) from exc
+
     result = response.json()
     return result.get("response", "")


### PR DESCRIPTION
## Summary
- handle request failures from Ollama by catching `requests.RequestException`
- log error details and raise `RuntimeError` with response text for easier debugging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68986be09d988332829388350d1ca633