### PR TITLE
Make SQL logging configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ export DATABASE_URL=postgresql://usuario:password@localhost:5432/gestorrequisito
 export SECRET_KEY=clave_secreta
 # URL base de Ollama (opcional, por defecto http://localhost:11434)
 export OLLAMA_URL=http://localhost:11434
+# Log SQL detallado (opcional, por defecto deshabilitado)
+export SQL_ECHO=true
 
 # Crear tablas
 python3 -m create_tables

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     database_url: str
     backend_cors_origins: str = "http://localhost:5173"
     ollama_url: str = "http://localhost:11434"
+    sql_echo: bool = False
 
     class Config:
         env_file = ".env"

--- a/app/database.py
+++ b/app/database.py
@@ -1,16 +1,8 @@
-from sqlmodel import SQLModel, Session, create_engine
-from pydantic_settings import BaseSettings
-import os
-
-class Settings(BaseSettings):
-    database_url: str
-
-    class Config:
-        env_file = ".env"
-        extra = "allow" 
+from sqlmodel import Session, create_engine
+from app.core.config import Settings
 
 settings = Settings()
-engine = create_engine(settings.database_url, echo=True)
+engine = create_engine(settings.database_url, echo=settings.sql_echo)
 
 def get_session():
     with Session(engine) as session:


### PR DESCRIPTION
## Summary
- add `sql_echo` flag to configuration
- respect `sql_echo` when creating the database engine
- document `SQL_ECHO` env var for verbose SQL logging

## Testing
- `pytest >/tmp/unit.log; tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68986be49b048332a4ad6796fd480f54