### PR TITLE
feat: generate category-specific requirements via AI

### DIFF
--- a/app/schemas/requirement.py
+++ b/app/schemas/requirement.py
@@ -1,7 +1,7 @@
 # schemas/requirement.py
 
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
 from datetime import datetime
 
 class RequirementCreate(BaseModel):
@@ -33,3 +33,10 @@ class RequirementUpdate(BaseModel):
     category: Optional[str] = None
     priority: Optional[str] = None
     visual_reference: Optional[str] = None
+
+
+class RequirementAIGenerateRequest(BaseModel):
+    project_id: int
+    category: str
+    language: Optional[str] = None
+    example_samples: Optional[List[str]] = None

--- a/app/services/requirement_service.py
+++ b/app/services/requirement_service.py
@@ -1,6 +1,6 @@
 import re
 from typing import List, Dict
-from sqlmodel import Session, select
+from sqlmodel import Session, select, func
 from app.models.requirement import Requirement
 
 CATS = ["FUNCTIONAL", "PERFORMANCE", "USABILITY", "SECURITY", "TECHNICAL"]
@@ -52,4 +52,29 @@ def replace_requirements(session: Session, project_id: int, parsed_items: List[D
             project_id=project_id,
             owner_id=owner_id,
         ))
+    session.commit()
+
+
+def append_requirements(session: Session, project_id: int, parsed_items: List[Dict], owner_id: int):
+    """Añade nuevos requisitos al proyecto manteniendo los existentes."""
+    last_number = (
+        session.exec(
+            select(func.max(Requirement.number)).where(Requirement.project_id == project_id)
+        ).first()
+        or 0
+    )
+    for it in parsed_items:
+        last_number += 1
+        session.add(
+            Requirement(
+                description=it["description"],
+                status=it["status"],
+                category=it["category"],
+                priority=it["priority"],
+                visual_reference=None,
+                number=last_number,
+                project_id=project_id,
+                owner_id=owner_id,
+            )
+        )
     session.commit()

--- a/app/static/messages/add_req_done_en.txt
+++ b/app/static/messages/add_req_done_en.txt
@@ -1,0 +1,1 @@
+AI has added new {category} requirements.

--- a/app/static/messages/add_req_done_es.txt
+++ b/app/static/messages/add_req_done_es.txt
@@ -1,0 +1,1 @@
+La IA ha añadido nuevos requisitos {category}.

--- a/app/static/prompts/add_requisites.txt
+++ b/app/static/prompts/add_requisites.txt
@@ -1,0 +1,24 @@
+Actúa como un ingeniero de requisitos profesional.
+
+Se te proporcionará la descripción de un proyecto de software, la lista de requisitos actuales y la categoría de requisitos a ampliar.
+
+Tu tarea es generar nuevos requisitos de la categoría {categoria_upper} sin repetir los existentes y manteniendo el estilo dado.
+
+IMPORTANTE:
+Usa exactamente este formato:
+{categoria_upper}:
+1. [primer requisito]
+2. [segundo requisito]
+continúa con los necesarios
+
+Descripción del sistema:
+"""
+{descripcion_usuario}
+"""
+
+Requisitos actuales:
+"""
+{requisitos_actuales}
+"""
+
+{ejemplo_requisitos_block}


### PR DESCRIPTION
## Summary
- add `/requirements/generate` endpoint to request new requirements for a given category while in `stall` state
- include prompt and localized confirmation messages for AI-generated requirements
- support appending new requirements without removing existing ones

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898738292548332b70be30c82be8b75