### PR TITLE
Add sample requirement file management endpoints

### DIFF
--- a/app/api/endpoints/files.py
+++ b/app/api/endpoints/files.py
@@ -1,0 +1,69 @@
+from fastapi import APIRouter, UploadFile, File, Depends, HTTPException, status
+from typing import List
+from sqlmodel import Session, select
+
+from app.database import get_session
+from app.api.endpoints.auth import get_current_user
+from app.models.user import User
+from app.models.sample_file import SampleFile
+from app.models.sample_requirement import SampleRequirement
+from app.schemas.sample_file import SampleFileRead
+
+router = APIRouter()
+
+
+@router.post("/upload", response_model=SampleFileRead, status_code=status.HTTP_201_CREATED)
+def upload_sample_file(
+    uploaded_file: UploadFile = File(...),
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    if not uploaded_file.filename.lower().endswith(".txt"):
+        raise HTTPException(status_code=400, detail="Only .txt files are allowed")
+
+    existing_files = session.exec(
+        select(SampleFile).where(SampleFile.owner_id == current_user.id)
+    ).all()
+    if len(existing_files) >= 5:
+        raise HTTPException(status_code=400, detail="Maximum number of files reached")
+
+    file_record = SampleFile(filename=uploaded_file.filename, owner_id=current_user.id)
+    session.add(file_record)
+    session.commit()
+    session.refresh(file_record)
+
+    content = uploaded_file.file.read().decode("utf-8")
+    for line in content.splitlines():
+        line = line.strip()
+        if line:
+            session.add(SampleRequirement(text=line, file_id=file_record.id))
+    session.commit()
+
+    return file_record
+
+
+@router.get("/", response_model=List[SampleFileRead])
+def list_sample_files(
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    files = session.exec(
+        select(SampleFile).where(SampleFile.owner_id == current_user.id)
+    ).all()
+    return files
+
+
+@router.get("/{file_id}/requirements", response_model=List[str])
+def get_sample_requirements(
+    file_id: int,
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+):
+    file_record = session.get(SampleFile, file_id)
+    if not file_record or file_record.owner_id != current_user.id:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    reqs = session.exec(
+        select(SampleRequirement).where(SampleRequirement.file_id == file_id)
+    ).all()
+    return [r.text for r in reqs]

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from app.api.endpoints import projects
 from app.api.endpoints import chat_message
 from app.api.endpoints import state_machine
 from app.api.endpoints import requirements
+from app.api.endpoints import files
 
 
 from fastapi.middleware.cors import CORSMiddleware
@@ -25,3 +26,4 @@ app.include_router(projects.router, prefix="/projects", tags=["projects"])
 app.include_router(chat_message.router, prefix="/chat_messages", tags=["chat_messages"])
 app.include_router(state_machine.router, prefix="/state_machine", tags=["state_machine"])
 app.include_router(requirements.router, prefix="/requirements", tags=["requirements"])
+app.include_router(files.router, prefix="/files", tags=["files"])

--- a/app/models/sample_file.py
+++ b/app/models/sample_file.py
@@ -1,0 +1,10 @@
+from typing import Optional
+from sqlmodel import SQLModel, Field
+
+
+class SampleFile(SQLModel, table=True):
+    """Represents a text file uploaded by a user containing sample requirements."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    filename: str
+    owner_id: int = Field(foreign_key="user.id")

--- a/app/models/sample_requirement.py
+++ b/app/models/sample_requirement.py
@@ -1,0 +1,10 @@
+from typing import Optional
+from sqlmodel import SQLModel, Field
+
+
+class SampleRequirement(SQLModel, table=True):
+    """A single sample requirement line parsed from an uploaded file."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    text: str
+    file_id: int = Field(foreign_key="samplefile.id")

--- a/app/schemas/sample_file.py
+++ b/app/schemas/sample_file.py
@@ -1,0 +1,6 @@
+from sqlmodel import SQLModel
+
+
+class SampleFileRead(SQLModel):
+    id: int
+    filename: str

--- a/create_tables.py
+++ b/create_tables.py
@@ -6,6 +6,8 @@ import app.models.project
 import app.models.chat_message
 import app.models.state_machine
 import app.models.requirement
+import app.models.sample_file
+import app.models.sample_requirement
 
 
 def create_db_and_tables():

--- a/tests/test_files_endpoints.py
+++ b/tests/test_files_endpoints.py
@@ -1,0 +1,55 @@
+import sys
+import os
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+os.environ.setdefault("database_url", "sqlite:///:memory:")
+
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, Session, create_engine
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.models.user import User
+from app.api.endpoints.auth import get_current_user
+from app.database import get_session
+
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+SQLModel.metadata.create_all(engine)
+
+
+def override_get_session():
+    with Session(engine) as session:
+        yield session
+
+
+def test_upload_and_retrieve_sample_file():
+    client = TestClient(app)
+    user = User(id=1, username="alice", email="alice@example.com", password_hash="hashed")
+
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_session] = override_get_session
+
+    content = "Req 1\nReq 2\n"
+    response = client.post(
+        "/files/upload",
+        files={"uploaded_file": ("reqs.txt", content, "text/plain")},
+    )
+    assert response.status_code == 201
+    file_id = response.json()["id"]
+
+    list_resp = client.get("/files/")
+    assert list_resp.status_code == 200
+    assert len(list_resp.json()) == 1
+
+    req_resp = client.get(f"/files/{file_id}/requirements")
+    assert req_resp.status_code == 200
+    assert req_resp.json() == ["Req 1", "Req 2"]
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- allow users to upload up to five .txt files and parse each line into sample requirements
- expose endpoints to list uploaded files and fetch requirements by file
- define SampleFile and SampleRequirement models, schema, router, and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898bcc8b940833296e95e517de8d8ef