### PR TITLE
Add secret key setting and update security configuration

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2,6 +2,7 @@ from pydantic_settings import BaseSettings
 from typing import List
 
 class Settings(BaseSettings):
+    secret_key: str
     database_url: str
     backend_cors_origins: str = "http://localhost:5173"
     ollama_url: str = "http://localhost:11434"

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -2,7 +2,9 @@ from passlib.context import CryptContext
 from jose import jwt, JWTError
 from datetime import datetime, timedelta
 
-from app.database import settings
+from app.core.config import Settings
+
+settings = Settings()
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 ALGORITHM = "HS256"

--- a/tests/test_auth_me.py
+++ b/tests/test_auth_me.py
@@ -5,6 +5,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 os.environ.setdefault("database_url", "sqlite:///:memory:")
+os.environ.setdefault("secret_key", "testsecret")
 
 from fastapi.testclient import TestClient
 from app.main import app

--- a/tests/test_auth_register_login.py
+++ b/tests/test_auth_register_login.py
@@ -16,8 +16,6 @@ from app.main import app
 from app.models.user import User
 from app.api.endpoints.auth import get_session
 from app.core.security import get_password_hash
-from app.database import settings as db_settings
-from app.api.endpoints import auth as auth_module
 
 
 engine = create_engine(
@@ -32,8 +30,6 @@ def override_get_session():
     with Session(engine) as session:
         yield session
 
-db_settings.secret_key = "testsecret"
-auth_module.settings.secret_key = "testsecret"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- add `secret_key` to Settings with environment support
- switch security module to its own Settings instance
- adjust tests to supply `secret_key` via env vars

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2af94bdb48332a0fe32f58922a9ae